### PR TITLE
Add session-backed auth for tender AI API

### DIFF
--- a/api/auth_extra.py
+++ b/api/auth_extra.py
@@ -1,15 +1,89 @@
-from fastapi import Request, Response
-from session_guard import issue_session, clear_session, rotate_all_sessions, require_session
+import base64
+import hashlib
+import hmac
+import secrets
+from fastapi import Request, HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from session_guard import (
+    issue_session,
+    clear_session,
+    rotate_all_sessions,
+    require_session,
+    bind_session_user,
+    get_session_user,
+    drop_session,
+)
+from storage import read_db
+
+
+class LoginBody(BaseModel):
+    username: str
+    password: str
+
+
+def _normalize_user(user: dict) -> dict:
+    base = {
+        "id": user.get("id"),
+        "username": user.get("username"),
+        "role": user.get("role", "member"),
+    }
+    for extra in ("canSeeProjects", "canSeeTenders", "permissions"):
+        if extra in user:
+            base[extra] = user[extra]
+    return base
+
+
+def _verify_password(user: dict, password: str) -> bool:
+    stored = user.get("passHash") or ""
+    if stored.startswith("PLAINTEXT:"):
+        return stored.split(":", 1)[1] == password
+    salt_b64 = user.get("salt") or ""
+    try:
+        salt = base64.b64decode(salt_b64)
+    except Exception:
+        return False
+    iterations = int(user.get("iterations") or 150000)
+    derived = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt, iterations).hex()
+    return hmac.compare_digest(derived, stored)
+
 
 def attach_auth_endpoints(app):
+    @app.post("/api/auth/login")
+    def login(body: LoginBody, request: Request):
+        username = body.username.strip().lower()
+        db = read_db()
+        users = db.get("nwgd_users") or []
+        user = next((u for u in users if str(u.get("username", "")).lower() == username), None)
+        if not user or not _verify_password(user, body.password):
+            raise HTTPException(status_code=401, detail="بيانات الدخول غير صحيحة")
+
+        session_id = secrets.token_urlsafe(32)
+        payload = _normalize_user(user)
+        resp = JSONResponse({"ok": True, "user": payload})
+        issue_session(resp, request, session_id)
+        bind_session_user(session_id, payload)
+        return resp
+
     @app.get("/api/auth/session-check")
     def session_check(request: Request):
         sid, meta = require_session(request)
-        return {"ok": True, "session_id": sid, **meta}
+        user = get_session_user(sid)
+        if not user:
+            drop_session(sid)
+            raise HTTPException(status_code=401, detail="Session user missing")
+        return {"ok": True, "session_id": sid, "user": user, **meta}
 
     @app.post("/api/auth/logout")
     def logout(request: Request):
-        resp = Response(content='{"ok":true}', media_type="application/json")
+        sid = None
+        try:
+            sid, _ = require_session(request)
+        except HTTPException:
+            pass
+        resp = JSONResponse({"ok": True})
+        if sid:
+            drop_session(sid)
         clear_session(resp)
         return resp
 

--- a/api/main.py
+++ b/api/main.py
@@ -1,38 +1,17 @@
 from routers import tender_ai
-import os, json, threading, sys
+import os, sys
 from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from typing import Any, Dict
+from typing import Any
 from datetime import datetime
+from .storage import read_db, write_db
 
-DATA_PATH = os.environ.get("DATA_PATH", "/data")
-os.makedirs(DATA_PATH, exist_ok=True)
-DB_FILE = os.path.join(DATA_PATH, "kv.json")
-LOCK = threading.Lock()
 SYNC_TOKEN = os.environ.get("SYNC_TOKEN")
 
 def log(*a):
     print("[API]", *a, file=sys.stdout, flush=True)
-
-def read_db() -> Dict[str, Any]:
-    with LOCK:
-        if not os.path.exists(DB_FILE):
-            return {}
-        try:
-            with open(DB_FILE, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception as e:
-            log("read_db error:", e)
-            return {}
-
-def write_db(data: Dict[str, Any]):
-    tmp = DB_FILE + ".tmp"
-    with LOCK:
-        with open(tmp, "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
-        os.replace(tmp, DB_FILE)
 
 app = FastAPI(title="Nawafed Team API", version="1.1")
 app.include_router(tender_ai.router)

--- a/api/routers/tender_ai.py
+++ b/api/routers/tender_ai.py
@@ -1,15 +1,20 @@
-from fastapi import APIRouter, UploadFile, File, Depends, Body, HTTPException
+from fastapi import APIRouter, UploadFile, File, Depends, Body, HTTPException, Request
 from typing import List, Optional
 from services.tender_ai_service import TenderAIService  # انتبه: بدون api.
+from ..session_guard import require_session, get_session_user
 
-# مؤقت: بدّلها بتحقق الجلسة الحقيقي عندك
-def require_user():
-    return {"id": 1, "name": "system"}
+
+def require_active_user(req: Request):
+    sid, _ = require_session(req)
+    user = get_session_user(sid)
+    if not user:
+        raise HTTPException(status_code=401, detail="Session user missing")
+    return user
 
 router = APIRouter(prefix="/api", tags=["tender-ai"])
 
 @router.post("/tenders/{tid}/files")
-async def upload_tender_file(tid: int, f: UploadFile = File(...), user=Depends(require_user)):
+async def upload_tender_file(tid: int, f: UploadFile = File(...), user=Depends(require_active_user)):
     svc = TenderAIService(user)
     rec = await svc.save_file(tid, f)
     return {"file_id": rec["id"], "filename": rec["filename"], "size": rec["size"]}
@@ -19,14 +24,14 @@ async def analyze_tender(
     tid: int,
     file_ids: Optional[List[int]] = Body(default=None),
     lang: str = Body(default="bi"),
-    user=Depends(require_user),
+    user=Depends(require_active_user),
 ):
     svc = TenderAIService(user)
     a = await svc.analyze(tid, file_ids=file_ids, lang=lang)
     return {"analysis_id": a["id"], "model": a["model"]}
 
 @router.get("/tenders/{tid}/analysis")
-async def get_latest_analysis(tid: int, user=Depends(require_user)):
+async def get_latest_analysis(tid: int, user=Depends(require_active_user)):
     svc = TenderAIService(user)
     a = await svc.get_latest_analysis(tid)
     if not a:

--- a/api/session_guard.py
+++ b/api/session_guard.py
@@ -1,5 +1,5 @@
 import os, time, hmac, hashlib, base64
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 from fastapi import Request, Response, HTTPException
 
 SESSION_SECRET = os.getenv("SESSION_SECRET", "")
@@ -10,7 +10,8 @@ SAMESITE      = os.getenv("SESSION_SAMESITE", "Lax")
 if not SESSION_SECRET:
     raise RuntimeError("SESSION_SECRET is empty")
 
-_SESS = {}  # session_id -> (ua_hash, ip_prefix, last_seen)
+_SESS: Dict[str, Tuple[str, str, int]] = {}
+_SESSION_USERS: Dict[str, dict] = {}
 
 def _sign(val: bytes) -> str:
     import hashlib, hmac, base64
@@ -50,11 +51,26 @@ def issue_session(resp: Response, req: Request, session_id: str) -> None:
         httponly=True, secure=True, samesite=SAMESITE, path="/"
     )
 
+def bind_session_user(session_id: str, user: dict) -> None:
+    """Attach user payload to an issued session."""
+    if not isinstance(user, dict):
+        raise ValueError("user must be a dict")
+    _SESSION_USERS[session_id] = dict(user)
+
+def get_session_user(session_id: str) -> Optional[dict]:
+    user = _SESSION_USERS.get(session_id)
+    return dict(user) if isinstance(user, dict) else None
+
+def drop_session(session_id: str) -> None:
+    _SESS.pop(session_id, None)
+    _SESSION_USERS.pop(session_id, None)
+
 def clear_session(resp: Response) -> None:
     resp.delete_cookie(COOKIE_NAME, path="/")
 
 def rotate_all_sessions() -> None:
     _SESS.clear()
+    _SESSION_USERS.clear()
 
 def require_session(req: Request) -> Tuple[str, dict]:
     c = req.cookies.get(COOKIE_NAME)
@@ -71,7 +87,7 @@ def require_session(req: Request) -> Tuple[str, dict]:
     ua_h, ip_p, last = rec
     now = int(time.time())
     if now - last > SESSION_IDLE:
-        _SESS.pop(sid, None)
+        drop_session(sid)
         raise HTTPException(status_code=401, detail="Idle timeout")
 
     if ua_h != _ua_hash(req):

--- a/api/storage.py
+++ b/api/storage.py
@@ -1,0 +1,28 @@
+import json
+import os
+import threading
+from typing import Any, Dict
+
+DATA_PATH = os.environ.get("DATA_PATH", "/data")
+os.makedirs(DATA_PATH, exist_ok=True)
+DB_FILE = os.path.join(DATA_PATH, "kv.json")
+_LOCK = threading.Lock()
+
+
+def read_db() -> Dict[str, Any]:
+    with _LOCK:
+        if not os.path.exists(DB_FILE):
+            return {}
+        try:
+            with open(DB_FILE, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return {}
+
+
+def write_db(data: Dict[str, Any]) -> None:
+    tmp = DB_FILE + ".tmp"
+    with _LOCK:
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        os.replace(tmp, DB_FILE)

--- a/web/index.html
+++ b/web/index.html
@@ -99,8 +99,7 @@
     }
     function useAuth(){
       const [users,setUsers]=useServerState("nwgd_users",[]);
-      const [session,setSession]=useServerState("nwgd_session",null);
-      const [sessionTokens,setSessionTokens]=useServerState("nwgd_session_tokens",{}); // reserved
+      const [session,setSession]=useState(null);
       const [booted,setBooted]=useState(false);
 
       useEffect(()=>{(async()=>{
@@ -113,39 +112,50 @@
         }
         setBooted(true);
       })()},[]);
+      useEffect(()=>{(async()=>{
+        try{
+          const r=await fetch(`${FORCED_SERVER.base}/auth/session-check`,{credentials:"include"});
+          if(r.ok){
+            const data=await r.json();
+            if(data?.user){
+              setSession({uid:data.user.id,username:data.user.username,role:data.user.role,lastActivity:Date.now()});
+            }
+          }else{
+            setSession(null);
+          }
+        }catch(e){ setSession(null); }
+      })()},[]);
       async function login(username,password){
-        const u=(users||[]).find(x=>x.username.toLowerCase()===String(username).toLowerCase());
-        if(!u) return {ok:false,msg:"المستخدم غير موجود"};
-        const h=await pbkdf2(password,u.salt,u.iterations||150000);
-        if(h!==u.passHash) return {ok:false,msg:"كلمة المرور غير صحيحة"};
-        const sid='s'+Date.now()+Math.random().toString(36).slice(2);
-        const exp=Date.now()+1000*60*60*24*30;
-        const tokens=Object.assign({},(await kvGet("nwgd_session_tokens"))||{});
-        tokens[sid]={uid:u.id,username:u.username,role:u.role,exp};
-        await kvPut("nwgd_session_tokens",tokens);
-        localStorage.setItem("nwgd_sid",sid);
-        setSession({uid:u.id,username:u.username,role:u.role,lastActivity:Date.now()});
+        let resp;
+        try{
+          resp=await fetch(`${FORCED_SERVER.base}/auth/login`,{
+            method:"POST",
+            headers:{"Content-Type":"application/json"},
+            body:JSON.stringify({username,password}),
+            credentials:"include"
+          });
+        }catch(e){
+          return {ok:false,msg:"تعذر الاتصال بالخادم"};
+        }
+        if(resp.status===401){
+          const err=await resp.json().catch(()=>({detail:""}));
+          return {ok:false,msg:err.detail||"بيانات الدخول غير صحيحة"};
+        }
+        if(!resp.ok){
+          return {ok:false,msg:"حدث خطأ أثناء تسجيل الدخول"};
+        }
+        const data=await resp.json().catch(()=>({}));
+        if(data?.user){
+          setSession({uid:data.user.id,username:data.user.username,role:data.user.role,lastActivity:Date.now()});
+        }
         return {ok:true};
       }
       async function logout(){
-        const sid=localStorage.getItem("nwgd_sid");
-        const tokens=Object.assign({},(await kvGet("nwgd_session_tokens"))||{});
-        delete tokens[sid];
-        await kvPut("nwgd_session_tokens",tokens);
-        localStorage.removeItem("nwgd_sid");
+        try{
+          await fetch(`${FORCED_SERVER.base}/auth/logout`,{method:"POST",credentials:"include"});
+        }catch(e){}
         setSession(null);
       }
-      useEffect(()=>{(async()=>{
-        try{
-          const sid=localStorage.getItem("nwgd_sid");
-          if(!sid) return;
-          const tokens=await kvGet("nwgd_session_tokens");
-          const t=tokens&&tokens[sid];
-          if(t && t.exp>Date.now()){
-            setSession({uid:t.uid,username:t.username,role:t.role,lastActivity:Date.now()});
-          }
-        }catch(e){}
-      })()},[]);
       return {users,setUsers,session,setSession,login,logout,booted};
     }
 

--- a/web/tenders.html
+++ b/web/tenders.html
@@ -295,15 +295,11 @@ function loadUiPrefs(){ try{ const j=JSON.parse(localStorage.getItem("tenders_ui
 // ====================== تحميل الجلسة والمستخدم ======================
 async function loadSessionAndUser(){
   try{
-    const session = await kvGet("nwgd_session").catch(()=>null);
-    const users = await kvGet("nwgd_users").catch(()=>null);
-    let username = session && session.username || session && session.user || "";
-    let role = "guest";
-    if(users && Array.isArray(users)){
-      const u = users.find(x=>x.username===username);
-      if(u) role = (u.role || "member");
-    }
-    state.currentUser = {username, role};
+    const resp = await fetch("/api/auth/session-check",{credentials:"include"});
+    if(!resp.ok) throw new Error("no session");
+    const data = await resp.json();
+    const user = data && data.user || {};
+    state.currentUser = {username: user.username || "", role: user.role || "guest"};
   }catch{
     state.currentUser = {username:"", role:"guest"};
   }
@@ -925,7 +921,7 @@ function renderRecycle(){
 async function updateHealth(){
   if(!FEATURES.healthcheck){ document.getElementById('apiHealth').style.display='none'; return; }
   const tag = document.getElementById('apiHealth');
-  try{ await kvGet('nwgd_session'); tag.textContent='API ✓'; tag.classList.remove('soft'); tag.classList.add('bg-emerald-50'); }
+  try{ const resp = await fetch('/api/health'); if(!resp.ok) throw new Error('bad'); tag.textContent='API ✓'; tag.classList.remove('soft'); tag.classList.add('bg-emerald-50'); }
   catch{ tag.textContent='API ✗'; tag.classList.remove('bg-emerald-50'); tag.classList.add('bg-rose-50'); }
 }
 
@@ -1035,7 +1031,7 @@ function bindStatic(){
   // نسخ احتياطي (admin)
   document.getElementById('backupBtn').onclick = async ()=>{
     if(FEATURES.permissions && state.currentUser.role!=="admin") return alert('غير مسموح');
-    const KEYS=['nwgd_tenders_v2','nwgd_users','nwgd_settings','nwgd_session','nwgd_session_tokens'];
+    const KEYS=['nwgd_tenders_v2','nwgd_users','nwgd_settings'];
     for(const k of KEYS){
       try{ const v = await kvGet(k); const blob=new Blob([JSON.stringify({key:k,value:v},null,2)],{type:'application/json'}); const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download=`backup-${k}-${new Date().toISOString().slice(0,19).replace(/[:T]/g,'-')}.json`; a.click(); }
       catch{ /* تجاهل */ }


### PR DESCRIPTION
## Summary
- add a shared storage helper and expose session helpers for binding users to sessions
- gate tender AI routes behind a session-backed user dependency and return 401 when missing
- implement cookie-based login/logout endpoints and update the web clients to rely on them

## Testing
- python -m compileall api web/index.html web/tenders.html

------
https://chatgpt.com/codex/tasks/task_e_68e18ebf68748325ac9020e8021286ea