### PR TITLE
Add Alembic dependency to API requirements

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -4,3 +4,5 @@ SQLAlchemy==2.0.32
 psycopg2-binary==2.9.9
 pydantic==2.8.2
 python-multipart==0.0.9
+
+alembic==1.13.*


### PR DESCRIPTION
## Summary
- add Alembic to the API requirements so migrations can run inside the container

## Testing
- not run (container lacks Docker Engine)

------
https://chatgpt.com/codex/tasks/task_e_68e19c53a1c883259e74943b984630ad