### PR TITLE
Fix tender AI router session import

### DIFF
--- a/api/routers/tender_ai.py
+++ b/api/routers/tender_ai.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, UploadFile, File, Depends, Body, HTTPException, Request
 from typing import List, Optional
 from services.tender_ai_service import TenderAIService  # انتبه: بدون api.
-from ..session_guard import require_session, get_session_user
+from session_guard import require_session, get_session_user
 
 
 def require_active_user(req: Request):


### PR DESCRIPTION
## Summary
- switch the tender AI router to use the absolute session_guard import to match the package structure

## Testing
- not run (environment lacks docker runtime)


------
https://chatgpt.com/codex/tasks/task_e_68e23dd4270c8325b57762304e01df82