### PR TITLE
Fix tender API base detection and configure Alembic

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+sqlalchemy.url = sqlite:///./local.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# target metadata is optional. We don't have declarative models yet, so keep it None.
+target_metadata = None
+
+
+def _get_database_url() -> str:
+    env_url = os.getenv("DATABASE_URL")
+    if env_url:
+        return env_url
+    ini_url = config.get_main_option("sqlalchemy.url")
+    if not ini_url:
+        raise RuntimeError(
+            "DATABASE_URL environment variable is not set and no fallback URL is configured in alembic.ini"
+        )
+    return ini_url
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = _get_database_url()
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    configuration = config.get_section(config.config_ini_section) or {}
+    configuration["sqlalchemy.url"] = _get_database_url()
+
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/20250913_tender_ai_intake.py
+++ b/alembic/versions/20250913_tender_ai_intake.py
@@ -2,7 +2,7 @@ from alembic import op
 import sqlalchemy as sa
 
 revision = "20250913_tender_ai_intake"
-down_revision = 'OCI'
+down_revision = None
 branch_labels = None
 depends_on = None
 

--- a/api/routers/tender_ai.py
+++ b/api/routers/tender_ai.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, UploadFile, File, Depends, Body, HTTPException, Request
 from typing import List, Optional
 from services.tender_ai_service import TenderAIService  # انتبه: بدون api.
-from ..session_guard import require_session, get_session_user
+from session_guard import require_session, get_session_user
 
 
 def require_active_user(req: Request):

--- a/web/tenders.html
+++ b/web/tenders.html
@@ -49,8 +49,35 @@
   };
 
   // إعدادات عامة
+  const resolveApiBase = () => {
+    const fallback = "http://projects-host:8001/api";
+    if (typeof window === "undefined" || !window.location) {
+      return fallback;
+    }
+
+    try {
+      const { protocol, hostname, port } = window.location;
+      if (!hostname) {
+        return fallback;
+      }
+
+      let targetPort = port;
+      if (port === "8080") {
+        targetPort = "8001";
+      } else if (!port && ["localhost", "127.0.0.1", "0.0.0.0"].includes(hostname)) {
+        targetPort = "8001";
+      }
+
+      const origin = `${protocol}//${hostname}${targetPort ? `:${targetPort}` : ""}`;
+      return `${origin.replace(/\/+$/, "")}/api`;
+    } catch (err) {
+      console.warn("Failed to resolve API base, using fallback", err);
+      return fallback;
+    }
+  };
+
   const FORCED_SERVER = {
-    base: "http://projects-host:8001/api",
+    base: resolveApiBase(),
     token: "HkOyJOCgRI3AUnu37tEZLSEoZJvTjv7j6ORlzWWRdciteHz6"
   };
   const TRASH_RETENTION_DAYS = 30; // سلة المهملات: 30 يوم


### PR DESCRIPTION
## Summary
- resolve the tender management UI API base dynamically so it works behind HTTPS and without the internal projects-host alias
- add Alembic configuration files and correct the tender AI intake migration metadata so `alembic upgrade head` can run

## Testing
- python -m compileall alembic

------
https://chatgpt.com/codex/tasks/task_e_68e23dd4270c8325b57762304e01df82