### PR TITLE
Ensure API session secret is configured

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: WLxG1oMgaFGeVADQuo8EYPSJLW2ch7HCsgmCQqliCbVpmzftQvEaYIrZkiBCPObm
+      SESSION_SECRET: ${SESSION_SECRET:-dev-session-secret-please-change}
       ORIGINS: http://${DOMAIN},https://${DOMAIN}
       DATA_PATH: /data
       SYNC_TOKEN: HkOyJOCgRI3AUnu37tEZLSEoZJvTjv7j6ORlzWWRdciteHz6

--- a/env.example
+++ b/env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env (which is git-ignored) and adjust values as needed.
+POSTGRES_DB=projects
+POSTGRES_USER=projects
+POSTGRES_PASSWORD=projects
+DOMAIN=localhost
+SESSION_SECRET=dev-session-secret-please-change

--- a/fix_phase1_api.sh
+++ b/fix_phase1_api.sh
@@ -162,6 +162,9 @@ else
 fi
 
 echo "==> Build & restart API container"
+if [ -z "${SESSION_SECRET:-}" ]; then
+  export SESSION_SECRET=dev-session-secret-please-change
+fi
 if command -v docker >/dev/null 2>&1 && [ -f docker-compose.yml ]; then
   docker compose build api
   docker compose up -d api

--- a/quick_fix_and_check.sh
+++ b/quick_fix_and_check.sh
@@ -1,4 +1,7 @@
 set -euo pipefail
+
+: "${SESSION_SECRET:=dev-session-secret-please-change}"
+export SESSION_SECRET
 sed -i 's/from api\.services /from services /' api/routers/tender_ai.py || true
 sed -i 's/from api\.utils /from utils /' api/services/tender_ai_service.py || true
 docker compose build api

--- a/setup_tender_ai.sh
+++ b/setup_tender_ai.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+: "${SESSION_SECRET:=dev-session-secret-please-change}"
+export SESSION_SECRET
+
 echo "==> إنشاء المجلدات"
 mkdir -p app/routers app/services app/utils alembic/versions
 

--- a/setup_tender_ai_full.sh
+++ b/setup_tender_ai_full.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
+: "${SESSION_SECRET:=dev-session-secret-please-change}"
+export SESSION_SECRET
+
 echo "==> Creating folders"
 mkdir -p app/routers app/services app/utils alembic/versions
 


### PR DESCRIPTION
## Summary
- add a SESSION_SECRET entry to the api service so FastAPI can import the session guard
- provide an env.example and export the same secret from helper scripts to keep host and container aligned

## Testing
- not run (docker is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24454211c8325a13a90a048ffae7d