### PR TITLE
Ensure SESSION_SECRET is externally configured

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: WLxG1oMgaFGeVADQuo8EYPSJLW2ch7HCsgmCQqliCbVpmzftQvEaYIrZkiBCPObm
-      SESSION_SECRET: ${SESSION_SECRET:-dev-session-secret-please-change}
+      SESSION_SECRET: ${SESSION_SECRET}
       ORIGINS: http://${DOMAIN},https://${DOMAIN}
       DATA_PATH: /data
       SYNC_TOKEN: HkOyJOCgRI3AUnu37tEZLSEoZJvTjv7j6ORlzWWRdciteHz6


### PR DESCRIPTION
## Summary
- require SESSION_SECRET to be supplied from the environment for the API service

## Testing
- `docker compose up -d --build` *(fails: docker is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24844931483258029a9c6a62e07fc