### PR TITLE
Mount Alembic files in API service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,8 @@ services:
       - db
     volumes:
       - /opt/nawafed/projects/data:/data
+      - ./alembic.ini:/app/alembic.ini:ro
+      - ./alembic:/app/alembic:ro
     ports:
       - "8001:8000"       # host:container  ← مهم
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- mount the Alembic configuration and migration directories into the API service as read-only volumes

## Testing
- docker compose up -d --build *(fails: docker not available in environment)*
- docker compose exec -T api alembic upgrade head *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e248baf3648325ab8508935fbd9c4a