### PR TITLE
Improve tender dashboard API base detection

### DIFF
--- a/web/tenders.html
+++ b/web/tenders.html
@@ -79,8 +79,37 @@
         const xhr = new XMLHttpRequest();
         xhr.open("GET", target, false);
         xhr.timeout = 1200;
+        xhr.setRequestHeader("Accept", "application/json, text/plain;q=0.8");
         xhr.send(null);
-        return xhr.status >= 200 && xhr.status < 400;
+
+        if (xhr.status >= 200 && xhr.status < 400) {
+          const contentType = (xhr.getResponseHeader("content-type") || "").toLowerCase();
+          const body = (xhr.responseText || "").trim();
+
+          // إذا عاد السيرفر صفحة HTML ثابتة فهذا يعني أن الـ API غير متوفر.
+          if (!contentType.includes("json") && body.startsWith("<")) {
+            return false;
+          }
+
+          if (!body) {
+            return true;
+          }
+
+          try {
+            const parsed = JSON.parse(body);
+            if (parsed && (parsed.status === "ok" || parsed.ok === true || parsed.healthy === true)) {
+              return true;
+            }
+          } catch (jsonErr) {
+            console.warn("Health check JSON parse failed", target, jsonErr);
+            return false;
+          }
+
+          // محتوى JSON صالح لكن بدون حقل متفق عليه، نعتبره صحيًا طالما أنه JSON.
+          return true;
+        }
+
+        return false;
       } catch (probeErr) {
         console.warn("API health probe failed for", target, probeErr);
         return false;


### PR DESCRIPTION
## Summary
- refine the tenders dashboard API resolver to detect when a public host returns HTML instead of a live API
- keep falling back to the internal projects-host API endpoint when the public API probe fails

## Testing
- Not run (docker is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24ae296f883259459756ca88d6859