### PR TITLE
Require session secret configuration for API service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       DATABASE_URL: postgresql+psycopg2://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       SECRET_KEY: WLxG1oMgaFGeVADQuo8EYPSJLW2ch7HCsgmCQqliCbVpmzftQvEaYIrZkiBCPObm
-      SESSION_SECRET: ${SESSION_SECRET}
+      SESSION_SECRET: ${SESSION_SECRET:?SESSION_SECRET must be set for session signing}
       ORIGINS: http://${DOMAIN},https://${DOMAIN}
       DATA_PATH: /data
       SYNC_TOKEN: HkOyJOCgRI3AUnu37tEZLSEoZJvTjv7j6ORlzWWRdciteHz6

--- a/env.example
+++ b/env.example
@@ -3,4 +3,7 @@ POSTGRES_DB=projects
 POSTGRES_USER=projects
 POSTGRES_PASSWORD=projects
 DOMAIN=localhost
+# SESSION_SECRET should also be exported in the shell or secrets store of the
+# deployment environment before running `docker compose up` so that the API
+# service receives the same value.
 SESSION_SECRET=dev-session-secret-please-change


### PR DESCRIPTION
## Summary
- require SESSION_SECRET to be defined when starting the API container
- document the need to export the session secret before running Compose

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e24cdf08b08325b9caca20c4a8e4a9