### PR TITLE
Fix storage import for main entry point

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Any
 from datetime import datetime
-from .storage import read_db, write_db
+from storage import read_db, write_db
 
 SYNC_TOKEN = os.environ.get("SYNC_TOKEN")
 


### PR DESCRIPTION
## Summary
- update the storage import in `api/main.py` to use an absolute module path so the app can be started as `main`

## Testing
- docker compose up -d --build *(fails: `docker` command not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25508d7608325a495f4a0d4a8ef15