### PR TITLE
Ensure storage helpers use absolute import

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -6,7 +6,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Any
 from datetime import datetime
-from storage import read_db, write_db
+from storage import read_db, write_db  # absolute import ensures uvicorn resolves helpers correctly
 
 SYNC_TOKEN = os.environ.get("SYNC_TOKEN")
 


### PR DESCRIPTION
## Summary
- add clarification comment to the storage helper import to document the absolute path requirement

## Testing
- docker compose up -d --build *(fails: `docker` command not found in container environment)*
- docker compose logs -f api *(fails: `docker` command not found in container environment)*
- docker compose exec -T api alembic upgrade head *(fails: `docker` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e25717cabc832597cc76f967e6056f