### PR TITLE
Handle raw JSON payloads in KV endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3,10 +3,7 @@ from routers.auth import router as auth_router
 from routers import tender_ai
 import os, sys
 from fastapi import FastAPI, Request, HTTPException
-from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from typing import Any
 from datetime import datetime
 from storage import read_db, write_db  # absolute import ensures uvicorn resolves helpers correctly
 
@@ -47,27 +44,45 @@ def kv_get(key: str):
     db = read_db()
     return {"key": key, "value": db.get(key, None)}
 
-class Body(BaseModel):
-    value: Any
+async def _extract_value(request: Request):
+    """Return the JSON value sent in the request body.
+
+    Legacy clients wrap the data as {"value": ...} while the browser code sends
+    the JSON payload directly. We accept both formats so the UI can persist
+    settings without breaking existing integrations.
+    """
+
+    try:
+        payload = await request.json()
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
+
+    if isinstance(payload, dict) and set(payload.keys()) == {"value"}:
+        return payload["value"]
+    return payload
+
 
 @app.put("/kv/{key}")
-async def kv_put(key: str, request: Request, body: Body):
+async def kv_put(key: str, request: Request):
     require_token(request)
+    value = await _extract_value(request)
     db = read_db()
-    db[key] = body.value
+    db[key] = value
     write_db(db)
     return {"ok": True}
 
+
 @app.patch("/kv/{key}")
-async def kv_merge(key: str, request: Request, body: Body):
+async def kv_merge(key: str, request: Request):
     require_token(request)
+    value = await _extract_value(request)
     db = read_db()
     cur = db.get(key, {})
-    if isinstance(cur, dict) and isinstance(body.value, dict):
-        cur.update(body.value)
+    if isinstance(cur, dict) and isinstance(value, dict):
+        cur.update(value)
         db[key] = cur
     else:
-        db[key] = body.value
+        db[key] = value
     write_db(db)
     return {"ok": True}
 


### PR DESCRIPTION
## Summary
- allow the KV PUT/PATCH endpoints to accept either wrapped or raw JSON payloads
- normalize the value extraction so the UI can persist data without triggering 5xx responses

## Testing
- python -m compileall api/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e3cb06167c8325a208847529338c49